### PR TITLE
[BTAT-111] Created FinancialDataConnector to DES

### DIFF
--- a/app/connectors/FinancialDataConnector.scala
+++ b/app/connectors/FinancialDataConnector.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import javax.inject.{Inject, Singleton}
+
+import models.{FinancialDataError, FinancialDataResponse, FinancialDataSuccess}
+import play.api.Logger
+import play.api.http.Status._
+import uk.gov.hmrc.play.config.ServicesConfig
+import uk.gov.hmrc.play.http.{HeaderCarrier, _}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+@Singleton
+class FinancialDataConnector @Inject()(val http: HttpGet) extends ServicesConfig with RawResponseReads {
+
+  lazy val desBaseUrl: String = baseUrl("des")
+  val getFinancialDataUrl: String => String = mtditid => s"$desBaseUrl/calculation-store/financial-data/MTDBSA/$mtditid"
+
+  def getFinancialData(mtditid: String)(implicit headerCarrier: HeaderCarrier): Future[FinancialDataResponse] = {
+
+    val url = getFinancialDataUrl(mtditid)
+    Logger.debug(s"[FinancialDataConnector][getFinancialData] - GET $url")
+
+    http.GET[HttpResponse](url) flatMap {
+      response =>
+        response.status match {
+          case OK =>
+            Logger.debug(s"[AuthConnector][getFinancialData] - RESPONSE status: ${response.status}, body: ${response.body}")
+            Future.successful(FinancialDataSuccess(response.json))
+          case _ =>
+            Logger.warn(s"[FinancialDataConnector][getFinancialData] - RESPONSE status: ${response.status}, body: ${response.body}")
+            Future.successful(FinancialDataError(response.status, response.body))
+        }
+    }
+  }
+}

--- a/app/connectors/RawResponseReads.scala
+++ b/app/connectors/RawResponseReads.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import uk.gov.hmrc.play.http.{HttpReads, HttpResponse}
+
+trait RawResponseReads {
+
+  implicit val httpReads: HttpReads[HttpResponse] = new HttpReads[HttpResponse] {
+    override def read(method: String, url: String, response: HttpResponse) = response
+  }
+
+}

--- a/app/models/FinancialDataResponse.scala
+++ b/app/models/FinancialDataResponse.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.JsValue
+
+sealed trait FinancialDataResponse
+case class FinancialDataSuccess(financialData: JsValue) extends FinancialDataResponse
+case class FinancialDataError(status: Int, message: String) extends FinancialDataResponse

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -157,6 +157,11 @@ microservice {
             port=8500
         }
 
+        des {
+            host=localhost
+            port=9083
+        }
+
     }
 }
 

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -40,9 +40,10 @@ object MicroServiceBuild extends Build with MicroService {
   def test(scope: String = "test,it"): Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% "hmrctest" % "2.3.0" % scope,
     "org.scalatest" %% "scalatest" % "3.0.0" % scope,
-    "org.scalatestplus" %% "play" % "1.2.0" % scope,
+    "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.0" % scope,
     "org.pegdown" % "pegdown" % "1.6.0" % scope,
-    "com.typesafe.play" %% "play-test" % PlayVersion.current % scope
+    "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
+    "org.mockito" % "mockito-core" % "2.7.17" % scope
   )
 
 }

--- a/test/connectors/FinancialDataConnectorSpec.scala
+++ b/test/connectors/FinancialDataConnectorSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import models.{FinancialDataError, FinancialDataSuccess}
+import play.api.libs.json.Json
+import play.mvc.Http.Status
+import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+
+
+class FinancialDataConnectorSpec extends UnitSpec with WithFakeApplication with MockHttp {
+
+  implicit val hc = HeaderCarrier()
+
+  val successResponse = HttpResponse(Status.OK, Some(Json.parse("{}")))
+  val badResponse = HttpResponse(Status.BAD_REQUEST, responseString = Some("Error Message"))
+  val expectedSuccess = FinancialDataSuccess(Json.parse("{}"))
+  val expectedBadResponse = FinancialDataError(Status.BAD_REQUEST, "Error Message")
+
+  object TestFinancialDataConnector extends FinancialDataConnector(mockHttpGet)
+
+  "FinancialDataConnector.getFinancialData" should {
+
+    "return Status (OK) and a JSON body when successful as a FinancialDataSuccess model" in {
+      setupMockHttpGet(TestFinancialDataConnector.getFinancialDataUrl("1234"))(successResponse)
+      val result = TestFinancialDataConnector.getFinancialData("1234")
+      val enrolResponse = await(result)
+      enrolResponse shouldBe expectedSuccess
+    }
+
+    "return FinancialDataError model in case of failure" in {
+      setupMockHttpGet(TestFinancialDataConnector.getFinancialDataUrl("1234"))(badResponse)
+      val result = TestFinancialDataConnector.getFinancialData("1234")
+      val enrolResponse = await(result)
+      enrolResponse shouldBe expectedBadResponse
+    }
+
+  }
+
+}

--- a/test/connectors/MockHttp.scala
+++ b/test/connectors/MockHttp.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.mockito.MockitoSugar
+import uk.gov.hmrc.play.http.{HttpGet, HttpPost, HttpResponse}
+import uk.gov.hmrc.play.test.UnitSpec
+
+import scala.concurrent.Future
+
+
+trait MockHttp extends UnitSpec with MockitoSugar with BeforeAndAfterEach {
+
+  val mockHttpGet: HttpGet = mock[HttpGet]
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockHttpGet)
+  }
+
+  def setupMockHttpGet(url: String)(response: HttpResponse): Unit =
+    when(mockHttpGet.GET[HttpResponse](ArgumentMatchers.eq(url))(ArgumentMatchers.any(), ArgumentMatchers.any())).thenReturn(Future.successful(response))
+}


### PR DESCRIPTION
The connector returns either a FinancialDataSuccess or FinancialDataError response based on a sealed trait FinantialDataResponse.

The success response returns the Json payload to the caller. The error returns the error status and code to propogate up if necessary (bubble up).

This can always be refactored if necessary going forward.

It also includes logging.