### PR TITLE
BTAT-116: Added route & controller to getEstimatedTaxLiability

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ sbt 'run 9082'
 To test the application execute
 
 ```
-sbt test
+sbt clean scalastyle coverage test it:test coverageOff coverageReport
 ```
 
 

--- a/app/connectors/FinancialDataConnector.scala
+++ b/app/connectors/FinancialDataConnector.scala
@@ -18,7 +18,7 @@ package connectors
 
 import javax.inject.{Inject, Singleton}
 
-import models.{FinancialDataError, FinancialDataResult, FinancialDataSuccess}
+import models.{FinancialDataError, FinancialDataResponseModel, FinancialData}
 import play.api.Logger
 import play.api.http.Status._
 import uk.gov.hmrc.play.config.ServicesConfig
@@ -33,7 +33,7 @@ class FinancialDataConnector @Inject()(val http: HttpGet) extends ServicesConfig
   lazy val desBaseUrl: String = baseUrl("des")
   val getFinancialDataUrl: String => String = mtditid => s"$desBaseUrl/calculation-store/financial-data/MTDBSA/$mtditid"
 
-  def getFinancialData(mtditid: String)(implicit headerCarrier: HeaderCarrier): Future[FinancialDataResult] = {
+  def getFinancialData(mtditid: String)(implicit headerCarrier: HeaderCarrier): Future[FinancialDataResponseModel] = {
 
     val url = getFinancialDataUrl(mtditid)
     Logger.debug(s"[FinancialDataConnector][getFinancialData] - GET $url")
@@ -43,7 +43,7 @@ class FinancialDataConnector @Inject()(val http: HttpGet) extends ServicesConfig
         response.status match {
           case OK =>
             Logger.debug(s"[AuthConnector][getFinancialData] - RESPONSE status: ${response.status}, body: ${response.body}")
-            Future.successful(FinancialDataSuccess(response.json))
+            Future.successful(FinancialData(response.json))
           case _ =>
             Logger.warn(s"[FinancialDataConnector][getFinancialData] - RESPONSE status: ${response.status}, body: ${response.body}")
             Future.successful(FinancialDataError(response.status, response.body))

--- a/app/controllers/EstimatedTaxLiabilityController.scala
+++ b/app/controllers/EstimatedTaxLiabilityController.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import javax.inject.{Inject, Singleton}
+
+import config.AppConfig
+import controllers.predicates.AuthenticationPredicate
+import play.api.mvc._
+import uk.gov.hmrc.play.microservice.controller.BaseController
+
+import scala.concurrent.Future
+
+@Singleton
+class EstimatedTaxLiabilityController @Inject()(implicit val appConfig: AppConfig,
+                                                val authentication: AuthenticationPredicate
+                                      ) extends BaseController {
+
+  val getEstimatedTaxLiability: Action[AnyContent] = authentication.async { implicit request =>
+		Future.successful(Ok("Hello world"))
+  }
+}

--- a/app/models/EstimatedTaxLiabilityResponseModel.scala
+++ b/app/models/EstimatedTaxLiabilityResponseModel.scala
@@ -18,14 +18,14 @@ package models
 
 import play.api.libs.json.Json
 
-sealed trait EstimatedTaxLiabilityResponse
+sealed trait EstimatedTaxLiabilityResponseModel
 
 case class EstimatedTaxLiability(total: BigDecimal,
                                  nic2: BigDecimal,
                                  nic4: BigDecimal,
-                                 incomeTax: BigDecimal) extends EstimatedTaxLiabilityResponse
+                                 incomeTax: BigDecimal) extends EstimatedTaxLiabilityResponseModel
 
-case class EstimatedTaxLiabilityError(status: Int, message: String) extends EstimatedTaxLiabilityResponse
+case class EstimatedTaxLiabilityError(status: Int, message: String) extends EstimatedTaxLiabilityResponseModel
 
 
 object EstimatedTaxLiability {

--- a/app/models/FinancialDataResponseModel.scala
+++ b/app/models/FinancialDataResponseModel.scala
@@ -14,18 +14,10 @@
  * limitations under the License.
  */
 
-package routes
+package models
 
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import play.api.libs.json.JsValue
 
-class RoutesSpec extends UnitSpec with WithFakeApplication {
-
-  val contextRoute: String = "/income-tax-view-change"
-
-  // Estimated Tax Liability routes
-  "The URL for the EstimatedTaxLiabilityController.getEstimateTaxLiability action" should {
-    s"be equal to $contextRoute/estimated-tax-liability" in {
-      controllers.routes.EstimatedTaxLiabilityController.getEstimatedTaxLiability("1234").url shouldBe s"$contextRoute/estimated-tax-liability/1234"
-    }
-  }
-}
+sealed trait FinancialDataResponseModel
+case class FinancialData(financialData: JsValue) extends FinancialDataResponseModel
+case class FinancialDataError(status: Int, message: String) extends FinancialDataResponseModel

--- a/app/services/EstimatedTaxLiabilityService.scala
+++ b/app/services/EstimatedTaxLiabilityService.scala
@@ -30,10 +30,10 @@ import scala.concurrent.Future
 @Singleton
 class EstimatedTaxLiabilityService @Inject()(val financialDataConnector: FinancialDataConnector) {
 
-  def getEstimatedTaxLiability(mtditid: String)(implicit headerCarrier: HeaderCarrier): Future[EstimatedTaxLiabilityResponse] = {
+  def getEstimatedTaxLiability(mtditid: String)(implicit headerCarrier: HeaderCarrier): Future[EstimatedTaxLiabilityResponseModel] = {
     Logger.debug("[EstimatedTaxLiabilityService][getEstimateTaxLiability] - Requesting Financial Data from Connector")
-    financialDataConnector.getFinancialData(mtditid).map[EstimatedTaxLiabilityResponse] {
-      case success: FinancialDataSuccess =>
+    financialDataConnector.getFinancialData(mtditid).map[EstimatedTaxLiabilityResponseModel] {
+      case success: FinancialData =>
         Logger.debug(s"[EstimatedTaxLiabilityService][getEstimateTaxLiability] - Retrieved Finacial Data:\n\n${success.financialData}")
         createEstimatedTaxLiabilityResponse(success.financialData)
       case error: FinancialDataError =>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,3 +1,3 @@
 # microservice specific routes
 
-GET        /estimated-tax-liability             @controllers.EstimatedTaxLiabilityController.getEstimatedTaxLiability
+GET        /estimated-tax-liability/:mtditid             @controllers.EstimatedTaxLiabilityController.getEstimatedTaxLiability(mtditid)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,3 +1,3 @@
 # microservice specific routes
 
-GET        /hello-world             @controllers.MicroserviceHelloWorld.hello
+GET        /estimated-tax-liability             @controllers.EstimatedTaxLiabilityController.getEstimatedTaxLiability

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -1,5 +1,5 @@
 # Add all the application routes to the app.routes file
 ->         /income-tax-view-change              app.Routes
-->         /                          health.Routes
+->         /                                    health.Routes
 
-GET        /admin/metrics             @com.kenshoo.play.metrics.MetricsController.metrics
+GET        /admin/metrics                       @com.kenshoo.play.metrics.MetricsController.metrics

--- a/it/controllers/EstimatedTaxLiabilityControllerSpec.scala
+++ b/it/controllers/EstimatedTaxLiabilityControllerSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import helpers.ComponentSpecBase
+import helpers.servicemocks.{AuthStub, FinancialDataStub}
+import play.api.http.Status
+import helpers.IntegrationTestConstants._
+import models.EstimatedTaxLiability
+
+class EstimatedTaxLiabilityControllerSpec extends ComponentSpecBase {
+  "subscribe" should {
+    "call the subscription service successfully when auth succeeds" in {
+      AuthStub.stubAuthorised()
+
+      FinancialDataStub.stubGetFinancialData(testMtditid, 1000.00, 300.00, 500.00)
+
+      val res = IncomeTaxViewChange.getEstimatedTaxLiability(testMtditid)
+
+      FinancialDataStub.verifyGetFinancialData(testMtditid)
+
+      res.status shouldBe Status.OK
+      res.json.as[EstimatedTaxLiability] shouldBe EstimatedTaxLiability(
+        total = 1800,
+        incomeTax = 1000,
+        nic2 = 300,
+        nic4 = 500
+      )
+    }
+    "fail when get authority fails" in {
+      AuthStub.stubUnatuhorised()
+
+      val res = IncomeTaxViewChange.getEstimatedTaxLiability(testMtditid)
+
+      res.status shouldBe Status.UNAUTHORIZED
+      res.body shouldBe empty
+    }
+  }
+}

--- a/it/helpers/ComponentSpecBase.scala
+++ b/it/helpers/ComponentSpecBase.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helpers
+
+import org.scalatest._
+import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.libs.ws.WSResponse
+import play.api.{Application, Environment, Mode}
+import uk.gov.hmrc.play.test.UnitSpec
+
+trait ComponentSpecBase extends UnitSpec
+  with GivenWhenThen with TestSuite
+  with GuiceOneServerPerSuite with ScalaFutures with IntegrationPatience with Matchers
+  with WiremockHelper with BeforeAndAfterEach with BeforeAndAfterAll with Eventually {
+
+  val mockHost = WiremockHelper.wiremockHost
+  val mockPort = WiremockHelper.wiremockPort.toString
+  val mockUrl = s"http://$mockHost:$mockPort"
+
+  def config: Map[String, String] = Map(
+    "microservice.services.auth.host" -> mockHost,
+    "microservice.services.auth.port" -> mockPort,
+    "microservice.services.des.host" -> mockHost,
+    "microservice.services.des.port" -> mockPort
+  )
+
+  override implicit lazy val app: Application = new GuiceApplicationBuilder()
+    .in(Environment.simple(mode = Mode.Dev))
+    .configure(config)
+    .build
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    startWiremock()
+  }
+
+  override def afterAll(): Unit = {
+    stopWiremock()
+    super.afterAll()
+  }
+
+  object IncomeTaxViewChange {
+    def get(uri: String): WSResponse = await(buildClient(uri).get())
+
+    def getEstimatedTaxLiability(mtditid: String): WSResponse = get(s"/estimated-tax-liability/$mtditid")
+  }
+}

--- a/it/helpers/IntegrationTestConstants.scala
+++ b/it/helpers/IntegrationTestConstants.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helpers
+
+import models.FinancialDataError
+import play.api.http.Status._
+import play.api.libs.json.{JsValue, Json}
+
+object IntegrationTestConstants {
+
+  val testMtditid = "XAITSA123456"
+  val testErrorResponse = FinancialDataError(INTERNAL_SERVER_ERROR, "Internal Server Error Message")
+
+  object GetFinancialDataResponse {
+    def successResponse(incomeTax: BigDecimal, nic2: BigDecimal, nic4: BigDecimal): JsValue =
+      Json.parse(s"""
+         |{
+         |   "incomeTax": $incomeTax,
+         |   "nic2": $nic2,
+         |   "nic4": $nic4
+         |}
+      """.stripMargin)
+
+    def failureResponse(code: String, reason: String): JsValue =
+      Json.parse(s"""
+         |{
+         |   "code": "$code",
+         |   "reason":"$reason"
+         |}
+      """.stripMargin)
+  }
+}

--- a/it/helpers/WiremockHelper.scala
+++ b/it/helpers/WiremockHelper.scala
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helpers
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock._
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration._
+import com.github.tomakehurst.wiremock.stubbing.StubMapping
+import org.scalatest.concurrent.{Eventually, IntegrationPatience}
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.libs.ws.WSClient
+
+object WiremockHelper extends Eventually with IntegrationPatience {
+  val wiremockPort = 11111
+  val wiremockHost = "localhost"
+  val url = s"http://$wiremockHost:$wiremockPort"
+
+  def verifyPost(uri: String, xmlBody: String): Unit = {
+      verify(postRequestedFor(urlEqualTo(uri)).withRequestBody(equalToXml(xmlBody)))
+  }
+
+  def verifyGet(uri: String): Unit = {
+     verify(getRequestedFor(urlEqualTo(uri)))
+  }
+
+  def stubGet(url: String, status: Integer, body: String): StubMapping =
+    stubFor(get(urlMatching(url))
+      .willReturn(
+        aResponse().
+          withStatus(status).
+          withBody(body)
+      )
+    )
+
+  def stubPost(url: String, status: Integer, responseBody: String): StubMapping =
+    stubFor(post(urlMatching(url))
+      .willReturn(
+        aResponse().
+          withStatus(status).
+          withBody(responseBody)
+      )
+    )
+
+  def stubPut(url: String, status: Integer, responseBody: String): StubMapping =
+    stubFor(put(urlMatching(url))
+      .willReturn(
+        aResponse().
+          withStatus(status).
+          withBody(responseBody)
+      )
+    )
+
+  def stubPatch(url: String, status: Integer, responseBody: String): StubMapping =
+    stubFor(patch(urlMatching(url))
+      .willReturn(
+        aResponse().
+          withStatus(status).
+          withBody(responseBody)
+      )
+    )
+
+  def stubDelete(url: String, status: Integer, responseBody: String): StubMapping =
+    stubFor(delete(urlMatching(url))
+      .willReturn(
+        aResponse().
+          withStatus(status).
+          withBody(responseBody)
+      )
+    )
+}
+
+trait WiremockHelper {
+  self: GuiceOneServerPerSuite =>
+
+  import WiremockHelper._
+
+  lazy val ws = app.injector.instanceOf[WSClient]
+
+  lazy val wmConfig = wireMockConfig().port(wiremockPort)
+  lazy val wireMockServer = new WireMockServer(wmConfig)
+
+  def startWiremock() = {
+    wireMockServer.start()
+    WireMock.configureFor(wiremockHost, wiremockPort)
+  }
+
+  def stopWiremock() = wireMockServer.stop()
+
+  def resetWiremock() = WireMock.reset()
+
+  def buildClient(path: String) = ws.url(s"http://localhost:$port/income-tax-view-change$path").withFollowRedirects(false)
+}
+

--- a/it/helpers/servicemocks/AuthStub.scala
+++ b/it/helpers/servicemocks/AuthStub.scala
@@ -14,18 +14,20 @@
  * limitations under the License.
  */
 
-package routes
+package helpers.servicemocks
 
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import helpers.WiremockHelper
+import play.api.http.Status
 
-class RoutesSpec extends UnitSpec with WithFakeApplication {
+object AuthStub {
 
-  val contextRoute: String = "/income-tax-view-change"
+  val postAuthoriseUrl = "/auth/authorise"
 
-  // Estimated Tax Liability routes
-  "The URL for the EstimatedTaxLiabilityController.getEstimateTaxLiability action" should {
-    s"be equal to $contextRoute/estimated-tax-liability" in {
-      controllers.routes.EstimatedTaxLiabilityController.getEstimatedTaxLiability("1234").url shouldBe s"$contextRoute/estimated-tax-liability/1234"
-    }
+  def stubAuthorised(): Unit = {
+    WiremockHelper.stubPost(postAuthoriseUrl, Status.OK, "{}")
+  }
+
+  def stubUnatuhorised(): Unit = {
+    WiremockHelper.stubPost(postAuthoriseUrl, Status.UNAUTHORIZED, "{}")
   }
 }

--- a/it/helpers/servicemocks/FinancialDataStub.scala
+++ b/it/helpers/servicemocks/FinancialDataStub.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helpers.servicemocks
+
+import helpers.{IntegrationTestConstants, WiremockHelper}
+import play.api.http.Status
+
+object FinancialDataStub {
+
+  val url: String => String = mtditid => s"/calculation-store/financial-data/MTDBSA/$mtditid"
+
+  def stubGetFinancialData(mtditid: String, incomeTax: BigDecimal, nic2: BigDecimal, nic4: BigDecimal): Unit = {
+    val financialDataResponse = IntegrationTestConstants.GetFinancialDataResponse.successResponse(incomeTax, nic2, nic4).toString()
+    WiremockHelper.stubGet(url(mtditid), Status.OK, financialDataResponse)
+  }
+
+  def verifyGetFinancialData(mtditid: String): Unit =
+    WiremockHelper.verifyGet(url(mtditid))
+}

--- a/it/uk/gov/hmrc/DELETEME
+++ b/it/uk/gov/hmrc/DELETEME
@@ -1,1 +1,0 @@
-file just here to enable commit of the directories

--- a/project/MicroServiceBuild.scala
+++ b/project/MicroServiceBuild.scala
@@ -44,7 +44,8 @@ object MicroServiceBuild extends Build with MicroService {
     "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.0" % scope,
     "org.pegdown" % "pegdown" % "1.6.0" % scope,
     "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
-    "org.mockito" % "mockito-core" % "2.7.17" % scope
+    "org.mockito" % "mockito-core" % "2.7.17" % scope,
+    "com.github.tomakehurst" % "wiremock" % "2.5.1" % scope
   )
 
 }

--- a/test/connectors/FinancialDataConnectorSpec.scala
+++ b/test/connectors/FinancialDataConnectorSpec.scala
@@ -16,7 +16,7 @@
 
 package connectors
 
-import models.{FinancialDataError, FinancialDataSuccess}
+import models.{FinancialDataError, FinancialData}
 import play.api.libs.json.Json
 import play.mvc.Http.Status
 import uk.gov.hmrc.play.http.{HeaderCarrier, HttpResponse}
@@ -29,14 +29,14 @@ class FinancialDataConnectorSpec extends UnitSpec with WithFakeApplication with 
 
   val successResponse = HttpResponse(Status.OK, Some(Json.parse("{}")))
   val badResponse = HttpResponse(Status.BAD_REQUEST, responseString = Some("Error Message"))
-  val expectedSuccess = FinancialDataSuccess(Json.parse("{}"))
+  val expectedSuccess = FinancialData(Json.parse("{}"))
   val expectedBadResponse = FinancialDataError(Status.BAD_REQUEST, "Error Message")
 
   object TestFinancialDataConnector extends FinancialDataConnector(mockHttpGet)
 
   "FinancialDataConnector.getFinancialData" should {
 
-    "return Status (OK) and a JSON body when successful as a FinancialDataSuccess model" in {
+    "return Status (OK) and a JSON body when successful as a FinancialData model" in {
       setupMockHttpGet(TestFinancialDataConnector.getFinancialDataUrl("1234"))(successResponse)
       val result = TestFinancialDataConnector.getFinancialData("1234")
       val enrolResponse = await(result)

--- a/test/controllers/EstimatedTaxLiabilityControllerSpec.scala
+++ b/test/controllers/EstimatedTaxLiabilityControllerSpec.scala
@@ -19,32 +19,93 @@ package controllers
 import auth.{MockAuthorisedUser, MockUnauthorisedUser}
 import config.MockAppConfig
 import controllers.predicates.AuthenticationPredicate
+import models.{EstimatedTaxLiability, EstimatedTaxLiabilityError}
 import play.api.http.Status
+import play.api.libs.json.Json
+import play.api.mvc.Result
 import play.api.test.FakeRequest
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import utils.MaterializerSupport
+
+import scala.concurrent.Future
 
 
-class EstimatedTaxLiabilityControllerSpec extends UnitSpec with WithFakeApplication {
+class EstimatedTaxLiabilityControllerSpec extends UnitSpec with WithFakeApplication with MockEstimatedTaxLiabilityService with MaterializerSupport {
+
+  val mtditid = "1234"
 
   "The EstimatedTaxLiabilityController.getEstimatedTaxLiability action" when {
 
-    "called with an Unauthenticated user" should {
+    "called with an Authenticated user" when {
 
-      object TestEstimatedTaxLiabilityController extends EstimatedTaxLiabilityController()(MockAppConfig, new AuthenticationPredicate(MockUnauthorisedUser))
+      object TestEstimatedTaxLiabilityController extends EstimatedTaxLiabilityController()(
+        appConfig = MockAppConfig,
+        authentication = new AuthenticationPredicate(MockAuthorisedUser),
+        estimatedTaxLiabilityService = mockEstimateTaxLiabilityService
+      )
 
-      "return Unauthorised (401)" in {
-        val result = TestEstimatedTaxLiabilityController.getEstimatedTaxLiability(FakeRequest())
-        status(result) shouldBe Status.UNAUTHORIZED
+      "a valid response from the Estimated Tax Liability Service" should {
+
+        val expectedJson = EstimatedTaxLiability(
+          total = 1000.56,
+          incomeTax = 200.54,
+          nic2 = 100.02,
+          nic4 = 700.00
+        )
+        def result: Future[Result] = {
+          setupMockEstimatedTaxLiabilityResponse(mtditid)(expectedJson)
+          TestEstimatedTaxLiabilityController.getEstimatedTaxLiability(mtditid)(FakeRequest())
+        }
+
+        "return a OK result (200)" in {
+          status(result) shouldBe Status.OK
+        }
+
+        "content type of result should be Application/Json" in {
+          await(result).body.contentType shouldBe Some("application/json")
+        }
+
+        "return the EstimatedTaxLiability JSON response" in {
+          await(bodyOf(result)) shouldBe Json.toJson(expectedJson).toString()
+        }
+      }
+
+      "an invalid response from the Estimated Tax Liability Service" should {
+
+        val expectedJson = EstimatedTaxLiabilityError(
+          status = Status.INTERNAL_SERVER_ERROR,
+          message = "Error Message"
+        )
+        def result: Future[Result] = {
+          setupMockEstimatedTaxLiabilityResponse(mtditid)(expectedJson)
+          TestEstimatedTaxLiabilityController.getEstimatedTaxLiability(mtditid)(FakeRequest())
+        }
+
+        "return a OK result (200)" in {
+          status(result) shouldBe Status.INTERNAL_SERVER_ERROR
+        }
+
+        "content type of result should be Application/Json" in {
+          await(result).body.contentType shouldBe Some("application/json")
+        }
+
+        "return the EstimatedTaxLiability JSON response" in {
+          await(jsonBodyOf(result)) shouldBe Json.toJson(expectedJson)
+        }
       }
     }
 
-    "called with an Authenticated user" should {
+    "called with an Unauthenticated user" should {
 
-      object TestEstimatedTaxLiabilityController extends EstimatedTaxLiabilityController()(MockAppConfig, new AuthenticationPredicate(MockAuthorisedUser))
+      object TestEstimatedTaxLiabilityController extends EstimatedTaxLiabilityController()(
+        appConfig = MockAppConfig,
+        authentication = new AuthenticationPredicate(MockUnauthorisedUser),
+        estimatedTaxLiabilityService = mockEstimateTaxLiabilityService
+      )
 
-      "return OK (200)" in {
-        val result = TestEstimatedTaxLiabilityController.getEstimatedTaxLiability(FakeRequest())
-        status(result) shouldBe Status.OK
+      "return Unauthorised (401)" in {
+        val result = TestEstimatedTaxLiabilityController.getEstimatedTaxLiability(mtditid)(FakeRequest())
+        status(result) shouldBe Status.UNAUTHORIZED
       }
     }
   }

--- a/test/controllers/EstimatedTaxLiabilityControllerSpec.scala
+++ b/test/controllers/EstimatedTaxLiabilityControllerSpec.scala
@@ -24,26 +24,26 @@ import play.api.test.FakeRequest
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
 
-class MicroserviceHelloWorldControllerSpec extends UnitSpec with WithFakeApplication {
+class EstimatedTaxLiabilityControllerSpec extends UnitSpec with WithFakeApplication {
 
-  "The MicroserviceHelloWorld.hello action" when {
+  "The EstimatedTaxLiabilityController.getEstimatedTaxLiability action" when {
 
     "called with an Unauthenticated user" should {
 
-      object TestController extends MicroserviceHelloWorld()(MockAppConfig, new AuthenticationPredicate(MockUnauthorisedUser))
+      object TestEstimatedTaxLiabilityController extends EstimatedTaxLiabilityController()(MockAppConfig, new AuthenticationPredicate(MockUnauthorisedUser))
 
       "return Unauthorised (401)" in {
-        val result = TestController.hello()(FakeRequest())
+        val result = TestEstimatedTaxLiabilityController.getEstimatedTaxLiability(FakeRequest())
         status(result) shouldBe Status.UNAUTHORIZED
       }
     }
 
-    "called with an authenticated user" should {
+    "called with an Authenticated user" should {
 
-      object TestController extends MicroserviceHelloWorld()(MockAppConfig, new AuthenticationPredicate(MockAuthorisedUser))
+      object TestEstimatedTaxLiabilityController extends EstimatedTaxLiabilityController()(MockAppConfig, new AuthenticationPredicate(MockAuthorisedUser))
 
       "return OK (200)" in {
-        val result = TestController.hello()(FakeRequest())
+        val result = TestEstimatedTaxLiabilityController.getEstimatedTaxLiability(FakeRequest())
         status(result) shouldBe Status.OK
       }
     }

--- a/test/controllers/MockEstimatedTaxLiabilityService.scala
+++ b/test/controllers/MockEstimatedTaxLiabilityService.scala
@@ -14,28 +14,28 @@
  * limitations under the License.
  */
 
-package services
+package controllers
 
-import connectors.FinancialDataConnector
-import models.FinancialDataResponseModel
+import models.EstimatedTaxLiabilityResponseModel
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.mockito.MockitoSugar
+import services.EstimatedTaxLiabilityService
 import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.Future
 
 
-trait MockFinancialDataConnector extends UnitSpec with MockitoSugar with BeforeAndAfterEach {
+trait MockEstimatedTaxLiabilityService extends UnitSpec with MockitoSugar with BeforeAndAfterEach {
 
-  val mockFinancialDataConnector: FinancialDataConnector = mock[FinancialDataConnector]
+  val mockEstimateTaxLiabilityService: EstimatedTaxLiabilityService = mock[EstimatedTaxLiabilityService]
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    reset(mockFinancialDataConnector)
+    reset(mockEstimateTaxLiabilityService)
   }
 
-  def setupMockFinancialDataResult(mtditid: String)(response: FinancialDataResponseModel): Unit =
-    when(mockFinancialDataConnector.getFinancialData(ArgumentMatchers.eq(mtditid))(ArgumentMatchers.any())).thenReturn(Future.successful(response))
+  def setupMockEstimatedTaxLiabilityResponse(mtditid: String)(response: EstimatedTaxLiabilityResponseModel): Unit =
+    when(mockEstimateTaxLiabilityService.getEstimatedTaxLiability(ArgumentMatchers.eq(mtditid))(ArgumentMatchers.any())).thenReturn(Future.successful(response))
 }

--- a/test/routes/RoutesSpec.scala
+++ b/test/routes/RoutesSpec.scala
@@ -14,23 +14,18 @@
  * limitations under the License.
  */
 
-package controllers
+package routes
 
-import javax.inject.{Inject, Singleton}
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
-import config.AppConfig
-import controllers.predicates.AuthenticationPredicate
-import play.api.mvc._
-import uk.gov.hmrc.play.microservice.controller.BaseController
+class RoutesSpec extends UnitSpec with WithFakeApplication {
 
-import scala.concurrent.Future
+  val contextRoute: String = "/income-tax-view-change"
 
-@Singleton
-class MicroserviceHelloWorld @Inject()(implicit val appConfig: AppConfig,
-                                       val authentication: AuthenticationPredicate
-                                      ) extends BaseController {
-
-  def hello(): Action[AnyContent] = authentication.async { implicit request =>
-		Future.successful(Ok("Hello world"))
+  // Estimated Tax Liability routes
+  "The URL for the EstimatedTaxLiabilityController.getEstimateTaxLiability action" should {
+    s"be equal to $contextRoute/estimated-tax-liability" in {
+      controllers.routes.EstimatedTaxLiabilityController.getEstimatedTaxLiability().url shouldBe s"$contextRoute/estimated-tax-liability"
+    }
   }
 }

--- a/test/services/EstimatedTaxLiabilityServiceSpec.scala
+++ b/test/services/EstimatedTaxLiabilityServiceSpec.scala
@@ -16,7 +16,7 @@
 
 package services
 
-import models.{EstimatedTaxLiability, EstimatedTaxLiabilityError, FinancialDataError, FinancialDataSuccess}
+import models.{EstimatedTaxLiability, EstimatedTaxLiabilityError, FinancialDataError, FinancialData}
 import play.api.libs.json.Json
 import play.mvc.Http.Status
 import uk.gov.hmrc.play.http.HeaderCarrier
@@ -35,7 +35,7 @@ class EstimatedTaxLiabilityServiceSpec extends UnitSpec with WithFakeApplication
     "a successful response is returned from the FinancialDataConnector" should {
 
       "return a correctly formatted EstimateTaxLiability model" in {
-        val financialData = FinancialDataSuccess(Json.parse(
+        val financialData = FinancialData(Json.parse(
           """
             |{
             |  "nic2":"200",

--- a/test/utils/MaterializerSupport.scala
+++ b/test/utils/MaterializerSupport.scala
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-package models
+package utils
 
-import play.api.libs.json.JsValue
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
 
-sealed trait FinancialDataResult
-case class FinancialDataSuccess(financialData: JsValue) extends FinancialDataResult
-case class FinancialDataError(status: Int, message: String) extends FinancialDataResult
+trait MaterializerSupport {
+  implicit val system = ActorSystem("Sys")
+  implicit val materializer = ActorMaterializer()
+}


### PR DESCRIPTION
**Notes:**

- This task has wired the route all the way through the controller, service and connector to DES (locally our stub).
- I've added an Integration Test for the controller which Wiremocks out the calls to Auth and to DES (our stub). 
- The MicroserviceHelloWorld controller was renamed and used as the starting point for this task. Thus the HelloWorld endpoints etc have been removed.
- Updated the readme to include amended test execution steps to include scalastyle, scoverage and integration tests