### PR TITLE
[Minor Refactors] Refactoring based on codebase walkthrough

### DIFF
--- a/app/controllers/EstimatedTaxLiabilityController.scala
+++ b/app/controllers/EstimatedTaxLiabilityController.scala
@@ -28,7 +28,6 @@ import services.EstimatedTaxLiabilityService
 import uk.gov.hmrc.play.bootstrap.controller.BaseController
 
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 
 @Singleton
 class EstimatedTaxLiabilityController @Inject()(implicit val appConfig: AppConfig,
@@ -38,13 +37,13 @@ class EstimatedTaxLiabilityController @Inject()(implicit val appConfig: AppConfi
 
   def getEstimatedTaxLiability(nino: String, year: String, calcType: String): Action[AnyContent] = authentication.async { implicit request =>
     Logger.debug(s"[EstimatedTaxLiabilityController][getEstimatedTaxLiability] - Requesting Estimate from EstimatedTaxLiabilityService for NINO: $nino")
-    estimatedTaxLiabilityService.getEstimatedTaxLiability(nino, year, calcType).flatMap {
+    estimatedTaxLiabilityService.getEstimatedTaxLiability(nino, year, calcType).map {
       case success: LastTaxCalculation =>
         Logger.debug(s"[EstimatedTaxLiabilityController][getEstimatedTaxLiability] - Successful Response: $success")
-        Future.successful(Ok(Json.toJson(success)))
+        Ok(Json.toJson(success))
       case error: LastTaxCalculationError =>
         Logger.debug(s"[EstimatedTaxLiabilityController][getEstimatedTaxLiability] - Error Response: $error")
-        Future.successful(Status(error.status)(Json.toJson(error)))
+        Status(error.status)(Json.toJson(error))
     }
   }
 }

--- a/app/controllers/predicates/AuthenticationPredicate.scala
+++ b/app/controllers/predicates/AuthenticationPredicate.scala
@@ -33,10 +33,10 @@ class AuthenticationPredicate @Inject()(val authorisedFunctions: AuthorisedFunct
     Action.async { implicit request =>
       authorisedFunctions.authorised() {
         action(request)
-      } recoverWith {
+      } recover {
         case _ =>
           Logger.debug("[AuthenticationPredicate][authenticated] Unauthorised Request to Backend. Propagating Unauthorised Response")
-          Future.successful(Unauthorized)
+          Unauthorized
       }
     }
 }

--- a/app/services/EstimatedTaxLiabilityService.scala
+++ b/app/services/EstimatedTaxLiabilityService.scala
@@ -35,7 +35,6 @@ class EstimatedTaxLiabilityService @Inject()(val financialDataConnector: Financi
     financialDataConnector.getLastEstimatedTaxCalculation(nino, year, calcType).map[LastTaxCalculationResponseModel] {
       case success: LastTaxCalculation =>
         Logger.debug(s"[EstimatedTaxLiabilityService][getEstimateTaxLiability] - Retrieved Financial Data:\n\n$success")
-        //TODO for now just return the Last Calculation amount.  Add additional calc breakdown data
         success
       case error: LastTaxCalculationError =>
         LastTaxCalculationError(error.status, error.message)

--- a/test/assets/TestConstants.scala
+++ b/test/assets/TestConstants.scala
@@ -17,16 +17,24 @@
 package assets
 
 import models.{LastTaxCalculation, LastTaxCalculationError}
+import play.api.libs.json.Json
 import play.mvc.Http.Status
+import uk.gov.hmrc.http.HttpResponse
 
 object TestConstants {
   object FinancialData {
+
     val testNino = "BB123456A"
     val testYear = "2018"
     val testCalcType = "it"
 
     val lastTaxCalc = LastTaxCalculation("testCalcId", "testTimestamp", 2345.67)
     val lastTaxCalculationError = LastTaxCalculationError(Status.INTERNAL_SERVER_ERROR, "Error Message")
+
+    //Connector Responses
+    val successResponse = HttpResponse(Status.OK, Some(Json.toJson(lastTaxCalc)))
+    val badJson = HttpResponse(Status.OK, responseJson = Some(Json.parse("{}")))
+    val badResponse = HttpResponse(Status.INTERNAL_SERVER_ERROR, responseString = Some("Error Message"))
 
   }
 }

--- a/test/assets/TestConstants.scala
+++ b/test/assets/TestConstants.scala
@@ -25,8 +25,7 @@ object TestConstants {
     val testYear = "2018"
     val testCalcType = "it"
 
-    val expectedLastTaxCalcResponse = LastTaxCalculation("testCalcId", "testTimestamp", 2345.67)
-
+    val lastTaxCalc = LastTaxCalculation("testCalcId", "testTimestamp", 2345.67)
     val lastTaxCalculationError = LastTaxCalculationError(Status.INTERNAL_SERVER_ERROR, "Error Message")
 
   }

--- a/test/auth/MockAuthorisedFunctions.scala
+++ b/test/auth/MockAuthorisedFunctions.scala
@@ -25,7 +25,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import uk.gov.hmrc.http.HeaderCarrier
 
 trait MockAuthorisedFunctions extends AuthorisedFunctions with MockitoSugar {
-  override val authConnector = mock[MicroserviceAuthConnector]
+  override val authConnector: MicroserviceAuthConnector = mock[MicroserviceAuthConnector]
 }
 
 object MockAuthorisedUser extends MockAuthorisedFunctions {

--- a/test/connectors/FinancialDataConnectorSpec.scala
+++ b/test/connectors/FinancialDataConnectorSpec.scala
@@ -20,21 +20,14 @@ import assets.TestConstants.FinancialData._
 import config.MicroserviceAppConfig
 import mocks.MockHttp
 import models.LastTaxCalculationError
-import play.api.libs.json.Json
 import play.mvc.Http.Status
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
-import uk.gov.hmrc.http.{ HeaderCarrier, HttpResponse }
 import uk.gov.hmrc.http.logging.Authorization
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import utils.TestSupport
 
-class FinancialDataConnectorSpec extends UnitSpec with WithFakeApplication with MockHttp {
+class FinancialDataConnectorSpec extends TestSupport with MockHttp {
 
-  implicit val hc = HeaderCarrier()
-
-  val successResponse = HttpResponse(Status.OK, Some(Json.toJson(lastTaxCalc )))
-  val badJson = HttpResponse(Status.OK, responseJson = Some(Json.parse("{}")))
-  val badResponse = HttpResponse(Status.INTERNAL_SERVER_ERROR, responseString = Some("Error Message"))
-
-  object TestFinancialDataConnector extends FinancialDataConnector(mockHttpGet, fakeApplication.injector.instanceOf[MicroserviceAppConfig])
+  object TestFinancialDataConnector extends FinancialDataConnector(mockHttpGet, app.injector.instanceOf[MicroserviceAppConfig])
 
   "FinancialDataConnector.getFinancialData" should {
 
@@ -65,9 +58,6 @@ class FinancialDataConnectorSpec extends UnitSpec with WithFakeApplication with 
       setupMockHttpGetFailed(getLastEstimatedTaxCalculationUrl(testNino, testYear, testCalcType))
       await(getLastEstimatedTaxCalculation(testNino, testYear, testCalcType)) shouldBe
         LastTaxCalculationError(Status.INTERNAL_SERVER_ERROR, s"Unexpected failed future")
-
     }
-
   }
-
 }

--- a/test/controllers/ControllerBaseSpec.scala
+++ b/test/controllers/ControllerBaseSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import play.api.libs.json.{Format, Json}
+import play.api.mvc.Result
+import utils.TestSupport
+
+import scala.concurrent.Future
+
+
+class ControllerBaseSpec extends TestSupport {
+
+  def checkStatusOf(result: Future[Result])(expectedStatus: Int): Unit = {
+    s"return status ($expectedStatus)" in {
+      status(result) shouldBe expectedStatus
+    }
+  }
+
+  def checkContentTypeOf(result: Future[Result])(expectedContentType: String): Unit = {
+    s"Content Type of result should be $expectedContentType" in {
+      await(result).body.contentType shouldBe Some(expectedContentType)
+    }
+  }
+
+  def checkBodyOf[A](result: Future[Result])(expectedBody: A)(implicit format: Format[A]): Unit = {
+    s"return the response body $expectedBody" in {
+      await(bodyOf(result)) shouldBe Json.toJson(expectedBody).toString
+    }
+  }
+}

--- a/test/controllers/ControllerBaseSpec.scala
+++ b/test/controllers/ControllerBaseSpec.scala
@@ -37,9 +37,9 @@ class ControllerBaseSpec extends TestSupport {
     }
   }
 
-  def checkBodyOf[A](result: Future[Result])(expectedBody: A)(implicit format: Format[A]): Unit = {
+  def checkJsonBodyOf[A](result: Future[Result])(expectedBody: A)(implicit format: Format[A]): Unit = {
     s"return the response body $expectedBody" in {
-      await(bodyOf(result)) shouldBe Json.toJson(expectedBody).toString
+      await(jsonBodyOf(result)) shouldBe Json.toJson(expectedBody)
     }
   }
 }

--- a/test/controllers/EstimatedTaxLiabilityControllerSpec.scala
+++ b/test/controllers/EstimatedTaxLiabilityControllerSpec.scala
@@ -25,29 +25,27 @@ import play.api.http.Status
 import play.api.libs.json.Json
 import play.api.mvc.Result
 import play.api.test.FakeRequest
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
-import utils.MaterializerSupport
+import utils.TestSupport
 
 import scala.concurrent.Future
 
 
-class EstimatedTaxLiabilityControllerSpec extends UnitSpec with WithFakeApplication with MockEstimatedTaxLiabilityService with MaterializerSupport {
+class EstimatedTaxLiabilityControllerSpec extends TestSupport with MockEstimatedTaxLiabilityService {
 
   "The EstimatedTaxLiabilityController.getEstimatedTaxLiability action" when {
 
     "called with an Authenticated user" when {
 
       object TestEstimatedTaxLiabilityController extends EstimatedTaxLiabilityController()(
-        appConfig = fakeApplication.injector.instanceOf[MicroserviceAppConfig],
+        appConfig = app.injector.instanceOf[MicroserviceAppConfig],
         authentication = new AuthenticationPredicate(MockAuthorisedUser),
         estimatedTaxLiabilityService = mockEstimateTaxLiabilityService
       )
 
       "a valid response from the Estimated Tax Liability Service" should {
 
-
         def result: Future[Result] = {
-          setupMockEstimatedTaxLiabilityResponse(testNino, testYear, testCalcType)(lastTaxCalc)
+          mockEstimateTaxLiabilityResponse(lastTaxCalc)
           TestEstimatedTaxLiabilityController.getEstimatedTaxLiability(testNino, testYear, testCalcType)(FakeRequest())
         }
 
@@ -67,7 +65,7 @@ class EstimatedTaxLiabilityControllerSpec extends UnitSpec with WithFakeApplicat
       "an invalid response from the Estimated Tax Liability Service" should {
 
         def result: Future[Result] = {
-          setupMockEstimatedTaxLiabilityResponse(testNino, testYear, testCalcType)(lastTaxCalculationError)
+          mockEstimateTaxLiabilityResponse(lastTaxCalculationError)
           TestEstimatedTaxLiabilityController.getEstimatedTaxLiability(testNino, testYear, testCalcType)(FakeRequest())
         }
 
@@ -88,7 +86,7 @@ class EstimatedTaxLiabilityControllerSpec extends UnitSpec with WithFakeApplicat
     "called with an Unauthenticated user" should {
 
       object TestEstimatedTaxLiabilityController extends EstimatedTaxLiabilityController()(
-        appConfig = fakeApplication.injector.instanceOf[MicroserviceAppConfig],
+        appConfig = app.injector.instanceOf[MicroserviceAppConfig],
         authentication = new AuthenticationPredicate(MockUnauthorisedUser),
         estimatedTaxLiabilityService = mockEstimateTaxLiabilityService
       )

--- a/test/controllers/EstimatedTaxLiabilityControllerSpec.scala
+++ b/test/controllers/EstimatedTaxLiabilityControllerSpec.scala
@@ -22,12 +22,7 @@ import config.MicroserviceAppConfig
 import controllers.predicates.AuthenticationPredicate
 import mocks.MockEstimatedTaxLiabilityService
 import play.api.http.Status
-import play.api.libs.json.Json
-import play.api.mvc.Result
 import play.api.test.FakeRequest
-import utils.TestSupport
-
-import scala.concurrent.Future
 
 
 class EstimatedTaxLiabilityControllerSpec extends ControllerBaseSpec with MockEstimatedTaxLiabilityService {
@@ -44,10 +39,8 @@ class EstimatedTaxLiabilityControllerSpec extends ControllerBaseSpec with MockEs
 
       "a valid response from the Estimated Tax Liability Service" should {
 
-        def result: Future[Result] = {
-          mockEstimateTaxLiabilityResponse(lastTaxCalc)
-          TestEstimatedTaxLiabilityController.getEstimatedTaxLiability(testNino, testYear, testCalcType)(FakeRequest())
-        }
+        mockEstimateTaxLiabilityResponse(lastTaxCalc)
+        lazy val result = TestEstimatedTaxLiabilityController.getEstimatedTaxLiability(testNino, testYear, testCalcType)(FakeRequest())
 
         checkStatusOf(result)(Status.OK)
         checkContentTypeOf(result)("application/json")
@@ -56,10 +49,8 @@ class EstimatedTaxLiabilityControllerSpec extends ControllerBaseSpec with MockEs
 
       "an invalid response from the Estimated Tax Liability Service" should {
 
-        def result: Future[Result] = {
-          mockEstimateTaxLiabilityResponse(lastTaxCalculationError)
-          TestEstimatedTaxLiabilityController.getEstimatedTaxLiability(testNino, testYear, testCalcType)(FakeRequest())
-        }
+        mockEstimateTaxLiabilityResponse(lastTaxCalculationError)
+        lazy val result = TestEstimatedTaxLiabilityController.getEstimatedTaxLiability(testNino, testYear, testCalcType)(FakeRequest())
 
         checkStatusOf(result)(Status.INTERNAL_SERVER_ERROR)
         checkContentTypeOf(result)("application/json")

--- a/test/controllers/EstimatedTaxLiabilityControllerSpec.scala
+++ b/test/controllers/EstimatedTaxLiabilityControllerSpec.scala
@@ -43,7 +43,7 @@ class EstimatedTaxLiabilityControllerSpec extends ControllerBaseSpec with MockEs
 
         checkStatusOf(result)(Status.OK)
         checkContentTypeOf(result)("application/json")
-        checkBodyOf(result)(lastTaxCalc)
+        checkJsonBodyOf(result)(lastTaxCalc)
       }
 
       "an invalid response from the Estimated Tax Liability Service" should {
@@ -53,7 +53,7 @@ class EstimatedTaxLiabilityControllerSpec extends ControllerBaseSpec with MockEs
 
         checkStatusOf(result)(Status.INTERNAL_SERVER_ERROR)
         checkContentTypeOf(result)("application/json")
-        checkBodyOf(result)(lastTaxCalculationError)
+        checkJsonBodyOf(result)(lastTaxCalculationError)
       }
     }
 

--- a/test/controllers/EstimatedTaxLiabilityControllerSpec.scala
+++ b/test/controllers/EstimatedTaxLiabilityControllerSpec.scala
@@ -30,7 +30,7 @@ import utils.TestSupport
 import scala.concurrent.Future
 
 
-class EstimatedTaxLiabilityControllerSpec extends TestSupport with MockEstimatedTaxLiabilityService {
+class EstimatedTaxLiabilityControllerSpec extends ControllerBaseSpec with MockEstimatedTaxLiabilityService {
 
   "The EstimatedTaxLiabilityController.getEstimatedTaxLiability action" when {
 
@@ -49,17 +49,9 @@ class EstimatedTaxLiabilityControllerSpec extends TestSupport with MockEstimated
           TestEstimatedTaxLiabilityController.getEstimatedTaxLiability(testNino, testYear, testCalcType)(FakeRequest())
         }
 
-        "return a OK result (200)" in {
-          status(result) shouldBe Status.OK
-        }
-
-        "content type of result should be Application/Json" in {
-          await(result).body.contentType shouldBe Some("application/json")
-        }
-
-        "return the LastTaxCalculation response" in {
-          await(bodyOf(result)) shouldBe Json.toJson(lastTaxCalc).toString
-        }
+        checkStatusOf(result)(Status.OK)
+        checkContentTypeOf(result)("application/json")
+        checkBodyOf(result)(lastTaxCalc)
       }
 
       "an invalid response from the Estimated Tax Liability Service" should {
@@ -69,17 +61,9 @@ class EstimatedTaxLiabilityControllerSpec extends TestSupport with MockEstimated
           TestEstimatedTaxLiabilityController.getEstimatedTaxLiability(testNino, testYear, testCalcType)(FakeRequest())
         }
 
-        "return a OK result (200)" in {
-          status(result) shouldBe Status.INTERNAL_SERVER_ERROR
-        }
-
-        "content type of result should be Application/Json" in {
-          await(result).body.contentType shouldBe Some("application/json")
-        }
-
-        "return the LastTaxCalculationError response" in {
-          await(jsonBodyOf(result)) shouldBe Json.toJson(lastTaxCalculationError)
-        }
+        checkStatusOf(result)(Status.INTERNAL_SERVER_ERROR)
+        checkContentTypeOf(result)("application/json")
+        checkBodyOf(result)(lastTaxCalculationError)
       }
     }
 
@@ -91,10 +75,9 @@ class EstimatedTaxLiabilityControllerSpec extends TestSupport with MockEstimated
         estimatedTaxLiabilityService = mockEstimateTaxLiabilityService
       )
 
-      "return Unauthorised (401)" in {
-        val result = TestEstimatedTaxLiabilityController.getEstimatedTaxLiability(testNino, testYear, testCalcType)(FakeRequest())
-        status(result) shouldBe Status.UNAUTHORIZED
-      }
+      lazy val result = TestEstimatedTaxLiabilityController.getEstimatedTaxLiability(testNino, testYear, testCalcType)(FakeRequest())
+
+      checkStatusOf(result)(Status.UNAUTHORIZED)
     }
   }
 }

--- a/test/controllers/EstimatedTaxLiabilityControllerSpec.scala
+++ b/test/controllers/EstimatedTaxLiabilityControllerSpec.scala
@@ -17,10 +17,9 @@
 package controllers
 
 import assets.TestConstants.FinancialData._
-import auth.{MockAuthorisedUser, MockUnauthorisedUser}
 import config.MicroserviceAppConfig
 import controllers.predicates.AuthenticationPredicate
-import mocks.MockEstimatedTaxLiabilityService
+import mocks.{MockAuthorisedUser, MockEstimatedTaxLiabilityService, MockUnauthorisedUser}
 import play.api.http.Status
 import play.api.test.FakeRequest
 

--- a/test/controllers/EstimatedTaxLiabilityControllerSpec.scala
+++ b/test/controllers/EstimatedTaxLiabilityControllerSpec.scala
@@ -47,7 +47,7 @@ class EstimatedTaxLiabilityControllerSpec extends UnitSpec with WithFakeApplicat
 
 
         def result: Future[Result] = {
-          setupMockEstimatedTaxLiabilityResponse(testNino, testYear, testCalcType)(expectedLastTaxCalcResponse)
+          setupMockEstimatedTaxLiabilityResponse(testNino, testYear, testCalcType)(lastTaxCalc)
           TestEstimatedTaxLiabilityController.getEstimatedTaxLiability(testNino, testYear, testCalcType)(FakeRequest())
         }
 
@@ -60,7 +60,7 @@ class EstimatedTaxLiabilityControllerSpec extends UnitSpec with WithFakeApplicat
         }
 
         "return the LastTaxCalculation response" in {
-          await(bodyOf(result)) shouldBe Json.toJson(expectedLastTaxCalcResponse).toString
+          await(bodyOf(result)) shouldBe Json.toJson(lastTaxCalc).toString
         }
       }
 

--- a/test/controllers/predicates/AuthenticationPredicateSpec.scala
+++ b/test/controllers/predicates/AuthenticationPredicateSpec.scala
@@ -17,18 +17,16 @@
 package controllers.predicates
 
 import auth.{MockAuthorisedUser, MockUnauthorisedUser}
-import org.scalatest.mockito.MockitoSugar
 import play.api.http.Status
 import play.api.mvc.Result
 import play.api.mvc.Results.Ok
 import play.api.test.FakeRequest
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import utils.TestSupport
 
 import scala.concurrent.Future
 
 
-class AuthenticationPredicateSpec extends UnitSpec with MockitoSugar with WithFakeApplication {
-
+class AuthenticationPredicateSpec extends TestSupport {
 
   "The AuthenticationPredicate.authenticated method" when {
 

--- a/test/controllers/predicates/AuthenticationPredicateSpec.scala
+++ b/test/controllers/predicates/AuthenticationPredicateSpec.scala
@@ -16,17 +16,17 @@
 
 package controllers.predicates
 
-import auth.{MockAuthorisedUser, MockUnauthorisedUser}
+import controllers.ControllerBaseSpec
+import mocks.{MockAuthorisedUser, MockUnauthorisedUser}
 import play.api.http.Status
 import play.api.mvc.Result
 import play.api.mvc.Results.Ok
 import play.api.test.FakeRequest
-import utils.TestSupport
 
 import scala.concurrent.Future
 
 
-class AuthenticationPredicateSpec extends TestSupport {
+class AuthenticationPredicateSpec extends ControllerBaseSpec {
 
   "The AuthenticationPredicate.authenticated method" when {
 
@@ -36,23 +36,13 @@ class AuthenticationPredicateSpec extends TestSupport {
     }.apply(FakeRequest())
 
     "called with an Unauthenticated user (No Bearer Token in Header)" should {
-
       object TestAuthenticationPredicate extends AuthenticationPredicate(MockUnauthorisedUser)
-
-      "return Unauthorised (401)" in {
-        status(result(TestAuthenticationPredicate)) shouldBe Status.UNAUTHORIZED
-      }
+      checkStatusOf(result(TestAuthenticationPredicate))(Status.UNAUTHORIZED)
     }
 
     "called with an authenticated user (Some Bearer Token in Header)" should {
-
       object TestAuthenticationPredicate extends AuthenticationPredicate(MockAuthorisedUser)
-
-      "return OK (200)" in {
-        status(result(TestAuthenticationPredicate)) shouldBe Status.OK
-      }
+      checkStatusOf(result(TestAuthenticationPredicate))(Status.OK)
     }
   }
-
-
 }

--- a/test/mocks/MockAuthorisedFunctions.scala
+++ b/test/mocks/MockAuthorisedFunctions.scala
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-package auth
+package mocks
 
 import config.MicroserviceAuthConnector
 import org.scalatest.mockito.MockitoSugar
 import uk.gov.hmrc.auth.core.authorise.EmptyPredicate
 import uk.gov.hmrc.auth.core.{AuthorisedFunctions, MissingBearerToken}
+import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.{ExecutionContext, Future}
-import uk.gov.hmrc.http.HeaderCarrier
 
 trait MockAuthorisedFunctions extends AuthorisedFunctions with MockitoSugar {
   override val authConnector: MicroserviceAuthConnector = mock[MicroserviceAuthConnector]

--- a/test/mocks/MockEstimatedTaxLiabilityService.scala
+++ b/test/mocks/MockEstimatedTaxLiabilityService.scala
@@ -16,9 +16,11 @@
 
 package mocks
 
+import assets.TestConstants.FinancialData.{testCalcType, testNino, testYear}
 import models.LastTaxCalculationResponseModel
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
+import org.mockito.stubbing.OngoingStubbing
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.mockito.MockitoSugar
 import services.EstimatedTaxLiabilityService
@@ -36,7 +38,8 @@ trait MockEstimatedTaxLiabilityService extends UnitSpec with MockitoSugar with B
     reset(mockEstimateTaxLiabilityService)
   }
 
-  def setupMockEstimatedTaxLiabilityResponse(nino: String, year: String, calcType: String)(response: LastTaxCalculationResponseModel): Unit =
+  def setupMockEstimatedTaxLiabilityResponse(nino: String, year: String, calcType: String)(response: LastTaxCalculationResponseModel)
+  : OngoingStubbing[Future[LastTaxCalculationResponseModel]] =
     when(mockEstimateTaxLiabilityService
       .getEstimatedTaxLiability(
         ArgumentMatchers.eq(nino),
@@ -44,4 +47,7 @@ trait MockEstimatedTaxLiabilityService extends UnitSpec with MockitoSugar with B
         ArgumentMatchers.eq(calcType))
       (ArgumentMatchers.any()))
       .thenReturn(Future.successful(response))
+
+  def mockEstimateTaxLiabilityResponse(lastTaxCalcResponse: LastTaxCalculationResponseModel): OngoingStubbing[Future[LastTaxCalculationResponseModel]] =
+    setupMockEstimatedTaxLiabilityResponse(testNino, testYear, testCalcType)(lastTaxCalcResponse)
 }

--- a/test/mocks/MockFinancialDataConnector.scala
+++ b/test/mocks/MockFinancialDataConnector.scala
@@ -16,10 +16,12 @@
 
 package mocks
 
+import assets.TestConstants.FinancialData.{testCalcType, testNino, testYear}
 import connectors.FinancialDataConnector
 import models.LastTaxCalculationResponseModel
 import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
+import org.mockito.stubbing.OngoingStubbing
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.mockito.MockitoSugar
 import uk.gov.hmrc.play.test.UnitSpec
@@ -36,10 +38,14 @@ trait MockFinancialDataConnector extends UnitSpec with MockitoSugar with BeforeA
     reset(mockFinancialDataConnector)
   }
 
-  def setupMockFinancialDataResult(nino: String, year: String, calcType: String)(response: LastTaxCalculationResponseModel): Unit =
+  def setupMockFinancialDataResult(nino: String, year: String, calcType: String)(response: LastTaxCalculationResponseModel)
+  : OngoingStubbing[Future[LastTaxCalculationResponseModel]] =
     when(mockFinancialDataConnector.getLastEstimatedTaxCalculation(
       ArgumentMatchers.eq(nino),
       ArgumentMatchers.eq(year),
       ArgumentMatchers.eq(calcType))(ArgumentMatchers.any()))
       .thenReturn(Future.successful(response))
+
+  def mockFinancialDataResult(taxCalcResponse: LastTaxCalculationResponseModel): OngoingStubbing[Future[LastTaxCalculationResponseModel]] =
+    setupMockFinancialDataResult(testNino, testYear, testCalcType)(taxCalcResponse)
 }

--- a/test/mocks/MockHttp.scala
+++ b/test/mocks/MockHttp.scala
@@ -20,10 +20,10 @@ import org.mockito.ArgumentMatchers
 import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.mockito.MockitoSugar
+import uk.gov.hmrc.http.{HeaderCarrier, HttpGet, HttpResponse}
 import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.Future
-import uk.gov.hmrc.http.{ HeaderCarrier, HttpGet, HttpResponse }
 
 
 trait MockHttp extends UnitSpec with MockitoSugar with BeforeAndAfterEach {

--- a/test/models/LastTaxCalculationResponseModelSpec.scala
+++ b/test/models/LastTaxCalculationResponseModelSpec.scala
@@ -19,9 +19,9 @@ package models
 import org.scalatest.Matchers
 import play.api.http.Status
 import play.api.libs.json.Json
-import uk.gov.hmrc.play.test.UnitSpec
+import utils.TestSupport
 
-class LastTaxCalculationResponseModelSpec extends UnitSpec with Matchers{
+class LastTaxCalculationResponseModelSpec extends TestSupport with Matchers {
 
   "LastTaxCalculationResponseMode model" when {
 

--- a/test/routes/RoutesSpec.scala
+++ b/test/routes/RoutesSpec.scala
@@ -16,9 +16,9 @@
 
 package routes
 
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import utils.TestSupport
 
-class RoutesSpec extends UnitSpec with WithFakeApplication {
+class RoutesSpec extends TestSupport {
 
   val contextRoute: String = "/income-tax-view-change"
 

--- a/test/routes/RoutesSpec.scala
+++ b/test/routes/RoutesSpec.scala
@@ -29,9 +29,8 @@ class RoutesSpec extends TestSupport {
   // Estimated Tax Liability routes
   "The URL for the EstimatedTaxLiabilityController.getEstimateTaxLiability action" should {
     s"be equal to $contextRoute/estimated-tax-liability" in {
-      controllers.routes.EstimatedTaxLiabilityController.getEstimatedTaxLiability(testNino, testYear, testCalcType).url.shouldBe(
-        s"$contextRoute/estimated-tax-liability/$testNino/$testYear/$testCalcType")
-
+      controllers.routes.EstimatedTaxLiabilityController.getEstimatedTaxLiability(testNino, testYear, testCalcType).url shouldBe
+        s"$contextRoute/estimated-tax-liability/$testNino/$testYear/$testCalcType"
     }
   }
 }

--- a/test/services/EstimatedTaxLiabilityServiceSpec.scala
+++ b/test/services/EstimatedTaxLiabilityServiceSpec.scala
@@ -22,9 +22,12 @@ import models._
 import play.mvc.Http.Status
 import utils.TestSupport
 
+import scala.concurrent.Future
+
 class EstimatedTaxLiabilityServiceSpec extends TestSupport with MockFinancialDataConnector {
 
   object TestEstimatedTaxLiabilityService extends EstimatedTaxLiabilityService(mockFinancialDataConnector)
+  def result: Future[LastTaxCalculationResponseModel] = TestEstimatedTaxLiabilityService.getEstimatedTaxLiability(testNino, testYear, testCalcType)
 
   "The EstimatedTaxLiabilityService.getEstimatedTaxLiability method" when {
 
@@ -32,16 +35,15 @@ class EstimatedTaxLiabilityServiceSpec extends TestSupport with MockFinancialDat
 
       "return a correctly formatted LastTaxCalculation model" in {
         mockFinancialDataResult(lastTaxCalc)
-        await(TestEstimatedTaxLiabilityService.getEstimatedTaxLiability(testNino, testYear, testCalcType)) shouldBe lastTaxCalc
+        await(result) shouldBe lastTaxCalc
       }
     }
 
     "an Error Response is returned from the FinancialDataConnector" should {
 
       "return a correctly formatted LastTaxCalculationError model" in {
-        val expectedResponse = LastTaxCalculationError(Status.INTERNAL_SERVER_ERROR, "Error Message")
         mockFinancialDataResult(lastTaxCalculationError)
-        await(TestEstimatedTaxLiabilityService.getEstimatedTaxLiability(testNino, testYear, testCalcType)) shouldBe expectedResponse
+        await(result) shouldBe lastTaxCalculationError
       }
     }
   }

--- a/test/services/EstimatedTaxLiabilityServiceSpec.scala
+++ b/test/services/EstimatedTaxLiabilityServiceSpec.scala
@@ -34,8 +34,8 @@ class EstimatedTaxLiabilityServiceSpec extends UnitSpec with WithFakeApplication
     "a successful response is returned from the FinancialDataConnector" should {
 
       "return a correctly formatted LastTaxCalculation model" in {
-        setupMockFinancialDataResult(testNino, testYear, testCalcType)(expectedLastTaxCalcResponse)
-        await(TestEstimatedTaxLiabilityService.getEstimatedTaxLiability(testNino, testYear, testCalcType)) shouldBe expectedLastTaxCalcResponse
+        setupMockFinancialDataResult(testNino, testYear, testCalcType)(lastTaxCalc)
+        await(TestEstimatedTaxLiabilityService.getEstimatedTaxLiability(testNino, testYear, testCalcType)) shouldBe lastTaxCalc
       }
     }
 

--- a/test/services/EstimatedTaxLiabilityServiceSpec.scala
+++ b/test/services/EstimatedTaxLiabilityServiceSpec.scala
@@ -16,16 +16,13 @@
 
 package services
 
+import assets.TestConstants.FinancialData._
 import mocks.MockFinancialDataConnector
 import models._
 import play.mvc.Http.Status
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
-import assets.TestConstants.FinancialData._
-import uk.gov.hmrc.http.HeaderCarrier
+import utils.TestSupport
 
-class EstimatedTaxLiabilityServiceSpec extends UnitSpec with WithFakeApplication with MockFinancialDataConnector {
-
-  implicit val hc: HeaderCarrier = HeaderCarrier()
+class EstimatedTaxLiabilityServiceSpec extends TestSupport with MockFinancialDataConnector {
 
   object TestEstimatedTaxLiabilityService extends EstimatedTaxLiabilityService(mockFinancialDataConnector)
 
@@ -34,7 +31,7 @@ class EstimatedTaxLiabilityServiceSpec extends UnitSpec with WithFakeApplication
     "a successful response is returned from the FinancialDataConnector" should {
 
       "return a correctly formatted LastTaxCalculation model" in {
-        setupMockFinancialDataResult(testNino, testYear, testCalcType)(lastTaxCalc)
+        mockFinancialDataResult(lastTaxCalc)
         await(TestEstimatedTaxLiabilityService.getEstimatedTaxLiability(testNino, testYear, testCalcType)) shouldBe lastTaxCalc
       }
     }
@@ -43,7 +40,7 @@ class EstimatedTaxLiabilityServiceSpec extends UnitSpec with WithFakeApplication
 
       "return a correctly formatted LastTaxCalculationError model" in {
         val expectedResponse = LastTaxCalculationError(Status.INTERNAL_SERVER_ERROR, "Error Message")
-        setupMockFinancialDataResult(testNino, testYear, testCalcType)(lastTaxCalculationError)
+        mockFinancialDataResult(lastTaxCalculationError)
         await(TestEstimatedTaxLiabilityService.getEstimatedTaxLiability(testNino, testYear, testCalcType)) shouldBe expectedResponse
       }
     }

--- a/test/utils/TestSupport.scala
+++ b/test/utils/TestSupport.scala
@@ -18,13 +18,13 @@ package utils
 
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterAll, Suite}
-import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.test.UnitSpec
 
 import scala.concurrent.ExecutionContext
 
-trait TestSupport extends UnitSpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterAll with MaterializerSupport {
+trait TestSupport extends UnitSpec with GuiceOneAppPerSuite with MockitoSugar with BeforeAndAfterAll with MaterializerSupport {
   this: Suite =>
 
   implicit val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]

--- a/test/utils/TestSupport.scala
+++ b/test/utils/TestSupport.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfterAll, Suite}
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.test.UnitSpec
+
+import scala.concurrent.ExecutionContext
+
+trait TestSupport extends UnitSpec with GuiceOneServerPerSuite with MockitoSugar with BeforeAndAfterAll with MaterializerSupport {
+  this: Suite =>
+
+  implicit val ec: ExecutionContext = app.injector.instanceOf[ExecutionContext]
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+
+}


### PR DESCRIPTION
- Remove scenarios where we were using `flatMap` to remove Futures only to then add the Future back in. Instead, just use `map`
- Unit Tests now use `GuiceOneAppPerSuite` as opposed to FakeApplication
- Test Constants have been updated so that consistent data is used throughout the tests
- Created a `ControllerBaseSpec` with some common methods for asserting Status, JsonBodyOf and ContentType.
- General cleanup of tests specs
- Moved the `MockAuthorisedFunctions` to the `mocks` package