### PR TITLE
MISUV-7718 | Added timeout to API call

### DIFF
--- a/app/config/MicroserviceAppConfig.scala
+++ b/app/config/MicroserviceAppConfig.scala
@@ -54,6 +54,8 @@ class MicroserviceAppConfig @Inject()(servicesConfig: ServicesConfig) {
     )
   }
 
+  val claimToAdjustTimeout: Int = servicesConfig.getInt("claim-to-adjust.timeout")
+
   val confidenceLevel:Int = servicesConfig.getInt("auth.confidenceLevel")
 
   val incomeTaxSubmissionStubUrl: String = loadConfig("submissionStubUrl")

--- a/app/connectors/ClaimToAdjustPoaConnector.scala
+++ b/app/connectors/ClaimToAdjustPoaConnector.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, StringContextOps}
 
 import javax.inject.Inject
+import scala.concurrent.duration.{Duration, SECONDS}
 import scala.concurrent.{ExecutionContext, Future}
 
 
@@ -42,6 +43,7 @@ class ClaimToAdjustPoaConnector @Inject() ( val appConfig: MicroserviceAppConfig
       .post(url"$endpoint")
       .withBody(Json.toJson(request))
       .setHeader(appConfig.getIFHeaders("1773"):_*)
+      .transform(_.withRequestTimeout(Duration(appConfig.claimToAdjustTimeout, SECONDS)))
       .execute[ClaimToAdjustPoaResponse]
       .recover {
         case e =>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -145,6 +145,8 @@ microservice {
     }
 }
 
+claim-to-adjust.timeout = 60
+
 submissionStubUrl = "http://localhost:9303"
 useBusinessDetailsIFPlatform = true
 useRepaymentHistoryDetailsIFPlatform = true


### PR DESCRIPTION
Added explicit timeout in claimToAdjustConnector, configured to 60 seconds in line with other production configuration