### PR TITLE
[MISUV-8534] Simplify Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This service is written in [Scala](http://www.scala-lang.org/) and [Play](http:/
 To update from Nexus and start all services from the RELEASE version instead of snapshot:
 
 ```
-sm --start ITVC_BACKEND_ALL -f
+sm2 --start ITVC_BACKEND_ALL -r
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ sbt 'run 9082'
 To test the application execute
 
 ```
-sbt clean scalastyle coverage test it:test coverageOff coverageReport
+sbt clean scalastyle coverage test it/test coverageOff coverageReport
 ```
 
 

--- a/app/connectors/ClaimToAdjustPoaConnector.scala
+++ b/app/connectors/ClaimToAdjustPoaConnector.scala
@@ -47,7 +47,7 @@ class ClaimToAdjustPoaConnector @Inject() ( val appConfig: MicroserviceAppConfig
       .execute[ClaimToAdjustPoaResponse]
       .recover {
         case e =>
-          Logger("application").error(s"[ClaimToAdjustPoaConnector] ${e.getMessage}")
+          Logger("application").error(s"${e.getMessage}")
           ClaimToAdjustPoaResponse(INTERNAL_SERVER_ERROR, Left(ErrorResponse(e.getMessage)))
       }
   }

--- a/app/connectors/httpParsers/ClaimToAdjustPoaHttpParser.scala
+++ b/app/connectors/httpParsers/ClaimToAdjustPoaHttpParser.scala
@@ -34,7 +34,7 @@ object ClaimToAdjustPoaHttpParser {
                 case JsSuccess(model, _) =>
                     ClaimToAdjustPoaResponse(CREATED, Right(model.successResponse))
                 case _ => {
-                    Logger("application").warn(s"[ClaimToAdjustPoaResponseReads] Invalid JSON in Claim To Adjust POA success response")
+                    Logger("application").warn("Invalid JSON in Claim To Adjust POA success response")
                     ClaimToAdjustPoaResponse(INTERNAL_SERVER_ERROR,
                         Left(ErrorResponse("Invalid JSON in success response")))
                 }
@@ -44,7 +44,7 @@ object ClaimToAdjustPoaHttpParser {
                     case JsSuccess(model, _) =>
                         ClaimToAdjustPoaResponse(status = status, Left(ErrorResponse(model.toString)))
                     case _ =>
-                        Logger("application").warn(s"[ClaimToAdjustPoaResponseReads] Invalid JSON in Claim To Adjust POA failure response")
+                        Logger("application").warn("Invalid JSON in Claim To Adjust POA failure response")
                         ClaimToAdjustPoaResponse(INTERNAL_SERVER_ERROR,
                             Left(ErrorResponse("Invalid JSON in failure response")))
                 }

--- a/app/controllers/ClaimToAdjustPoaController.scala
+++ b/app/controllers/ClaimToAdjustPoaController.scala
@@ -42,7 +42,7 @@ class ClaimToAdjustPoaController @Inject()(authentication: AuthenticationPredica
             response.claimToAdjustPoaBody match {
             case Right(x: SuccessResponse)  => Created(Json.toJson(x))
             case Left(e: ErrorResponse)     =>
-              Logger("application").error(s"[ClaimToAdjustPoaController] ${e.message}")
+              Logger("application").error(s"${e.message}")
               Status(response.status)(Json.toJson(e))
           }
         }


### PR DESCRIPTION
This is to remove the unnecessary logging of the class name/functions in the logging due to them already being given within the logback files.

The changes to the logback files were already done before so they already produce the class within the logging.

Few logs still included class files, so only 3 files were affected.